### PR TITLE
chore: account data hooks

### DIFF
--- a/examples/nextjs-siwop/.gitignore
+++ b/examples/nextjs-siwop/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/examples/nextjs-siwop/src/pages/_app.tsx
+++ b/examples/nextjs-siwop/src/pages/_app.tsx
@@ -23,6 +23,7 @@ function App({ Component, pageProps }: AppProps) {
       <QueryClientProvider client={queryClient}>
         <siwopClient.Provider>
           <OPConnectProvider mode={mode} primaryColor={primaryColor} options={{
+            // NOTE: enter your own terms and privacy policy URLs here
             disclaimer: (
               <div>
                 By connecting your wallet you agree to the{' '}

--- a/examples/nextjs-siwop/src/utils/siwopClient.ts
+++ b/examples/nextjs-siwop/src/utils/siwopClient.ts
@@ -1,7 +1,6 @@
 import { configureClientSIWOP } from '@otherpage/connect-next-siwop';
 
 export const siwopClient = configureClientSIWOP({
-  appUrl: 'http://127.0.0.1:3001', // DEV: for non-production enviroments only
   apiRoutePrefix: '/api/siwop',
   clientId: process.env.NEXT_PUBLIC_SIWOP_CLIENT_ID as string,
   redirectUri: process.env.NEXT_PUBLIC_SIWOP_REDIRECT_URI as string,

--- a/examples/nextjs-siwop/src/utils/siwopClient.ts
+++ b/examples/nextjs-siwop/src/utils/siwopClient.ts
@@ -1,10 +1,10 @@
 import { configureClientSIWOP } from '@otherpage/connect-next-siwop';
 
 export const siwopClient = configureClientSIWOP({
-  // appUrl: 'http://127.0.0.1:3001', // For non-production enviroments only
-  apiRoutePrefix: '/api/siwop', // Your API route directory
-  clientId: process.env.NEXT_PUBLIC_SIWOP_CLIENT_ID as string, // Your SIWOP client ID
-  redirectUri: process.env.NEXT_PUBLIC_SIWOP_REDIRECT_URI as string, // Your SIWOP redirect URI
+  appUrl: 'http://127.0.0.1:3001', // DEV: for non-production enviroments only
+  apiRoutePrefix: '/api/siwop',
+  clientId: process.env.NEXT_PUBLIC_SIWOP_CLIENT_ID as string,
+  redirectUri: process.env.NEXT_PUBLIC_SIWOP_REDIRECT_URI as string,
   scope: [
     'avatar.read',
     'wallets.read',

--- a/examples/nextjs-siwop/src/utils/siwopServer.ts
+++ b/examples/nextjs-siwop/src/utils/siwopServer.ts
@@ -1,11 +1,7 @@
 import { configureServerSideSIWOP } from '@otherpage/connect-next-siwop';
 
-const API_URL = 'http://127.0.0.1:3003/v1'; // DEV: for non-production enviroments only
-// const API_URL = 'https://alpha-api.other.page/v1';
-
 export const siwopServer = configureServerSideSIWOP({
   config: {
-    authApiUrl: API_URL,
     audience: '127.0.0.1:3004',
     clientId: process.env.NEXT_PUBLIC_SIWOP_CLIENT_ID,
     redirectUri: process.env.NEXT_PUBLIC_SIWOP_REDIRECT_URI,
@@ -33,6 +29,8 @@ export const siwopServer = configureServerSideSIWOP({
 });
 
 // --- example --- //
+
+const API_URL = 'https://alpha-api.other.page/v1';
 
 async function getAccount(
   accessToken: string  

--- a/examples/nextjs-siwop/src/utils/siwopServer.ts
+++ b/examples/nextjs-siwop/src/utils/siwopServer.ts
@@ -1,7 +1,7 @@
 import { configureServerSideSIWOP } from '@otherpage/connect-next-siwop';
 
-// const API_URL = 'http://127.0.0.1:3003/v1';
-const API_URL = 'https://alpha-api.other.page/v1';
+const API_URL = 'http://127.0.0.1:3003/v1'; // DEV: for non-production enviroments only
+// const API_URL = 'https://alpha-api.other.page/v1';
 
 export const siwopServer = configureServerSideSIWOP({
   config: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opconnect-packages",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Other Page Wallet Connect",
   "main": "packages/opconnect/src/index.ts",
   "private": true,

--- a/packages/opconnect-next-siwop/src/configureSIWOP.tsx
+++ b/packages/opconnect-next-siwop/src/configureSIWOP.tsx
@@ -73,6 +73,7 @@ type NextSIWOPSession<TSessionData extends Object = {}> = IronSession &
     codeChallenge?: string;
     nonce?: string;
     address?: string;
+    avatar?: string;
     chainId?: number;
     uid?: string;
   };
@@ -200,6 +201,9 @@ const sessionRoute = async (
   switch (req.method) {
     case 'GET':
       const session = await getSession(req, res, sessionConfig);
+
+      // TODO fetch avatar image/name
+      
       if (afterCallback) {
         await afterCallback(req, res, session);
       }
@@ -252,8 +256,12 @@ const verifyCodeRoute = async (
 
         // persist session data
         const decoded = jwtDecode(data.access_token);
-        session.address = decoded.wallet;
+        session.address = decoded.addr;
+        session.avatar = decoded.avatar;
         session.uid = decoded.sub;
+
+        // TODO fetch avatar image/name
+
         await session.save();
         
         if (afterCallback) {

--- a/packages/opconnect-next-siwop/src/configureSIWOP.tsx
+++ b/packages/opconnect-next-siwop/src/configureSIWOP.tsx
@@ -9,7 +9,7 @@ import {
 } from 'viem/siwe';
 import { generatePKCE, jwtDecode, JwtPayload } from './util';
 
-const APP_URL = 'https://alpha.other.page';
+
 const API_URL = 'https://alpha-api.other.page/v1';
 
 type RouteHandlerOptions = {
@@ -339,14 +339,12 @@ export const configureServerSideSIWOP = <TSessionData extends Object = {}>({
 };
 
 export const configureClientSIWOP = <TSessionData extends Object = {}>({
-  appUrl,
   apiRoutePrefix,
   clientId,
   redirectUri,
   scope,
 }: NextClientSIWOPConfig): ConfigureClientSIWOPResult<TSessionData> => {
   const NextSIWOPProvider = (props: NextSIWOPProviderProps) => {
-    const URL = appUrl || APP_URL;
     return (
       <SIWOPProvider
         clientId={clientId}

--- a/packages/opconnect-next-siwop/src/util.ts
+++ b/packages/opconnect-next-siwop/src/util.ts
@@ -20,7 +20,8 @@ export interface JwtPayload {
   jti?: string;
   // custom
   uid?: string;
-  wallet?: string;
+  addr?: string;
+  avatar?: string;
   cid?: string;
   scope?: string;
 }

--- a/packages/opconnect/src/components/Pages/SignInWithOtherPage/index.tsx
+++ b/packages/opconnect/src/components/Pages/SignInWithOtherPage/index.tsx
@@ -28,17 +28,20 @@ import Logos from '../../../assets/logos';
 import Button from '../../Common/Button';
 import { SIWOPButton } from '../../Standard/SIWOP';
 import FitText from '../../Common/FitText';
+import { ImageContainer } from '../../Common/Avatar/styles';
 
 const transition = { duration: 0.2, ease: [0.26, 0.08, 0.25, 1] };
 const copyTransition = { duration: 0.16, ease: [0.26, 0.08, 0.25, 1] };
 
 const SignInWithOtherPage: React.FC = () => {
-  const { clientId, appUrl, isSignedIn, error } = useSIWOP();
+  const { clientId, appUrl, isSignedIn, error, data } = useSIWOP();
   const mobile = isMobile();
 
   const [status, setStatus] = useState<'signedOut' | 'signedIn'>(
     isSignedIn ? 'signedIn' : 'signedOut'
   );
+
+  console.log(data);
 
   const locales = useLocales({});
   const copy = {
@@ -120,7 +123,11 @@ const SignInWithOtherPage: React.FC = () => {
           >
             <LogoContainer>
               {/* TODO Connected OP Avatar? */}
-              <Avatar address={address} width={64} height={64} />
+              {data?.avatarImage ? (
+                <ImageContainer src={data.avatarImage} alt="avatar" $loaded={true} />
+              ) : (
+                <Avatar address={address} width={64} height={64} />
+              )}
             </LogoContainer>
           </motion.div>
           <motion.div

--- a/packages/opconnect/src/components/Pages/SignInWithOtherPage/index.tsx
+++ b/packages/opconnect/src/components/Pages/SignInWithOtherPage/index.tsx
@@ -33,7 +33,7 @@ const transition = { duration: 0.2, ease: [0.26, 0.08, 0.25, 1] };
 const copyTransition = { duration: 0.16, ease: [0.26, 0.08, 0.25, 1] };
 
 const SignInWithOtherPage: React.FC = () => {
-  const { clientId, isSignedIn, error } = useSIWOP();
+  const { clientId, appUrl, isSignedIn, error } = useSIWOP();
   const mobile = isMobile();
 
   const [status, setStatus] = useState<'signedOut' | 'signedIn'>(
@@ -66,8 +66,7 @@ const SignInWithOtherPage: React.FC = () => {
   const openAccount = () => {
     const left = (window.innerWidth / 2) - 400;
     const top = (window.innerHeight / 2) - 380;
-    // TODO domain from Context
-    window.open(`https://alpha.other.page/connect/settings?client_id=${clientId}`, "mozillaWindow", `left=${left},top=${top},width=800,height=760`)
+    window.open(`${appUrl}/connect/settings?client_id=${clientId}`, "mozillaWindow", `left=${left},top=${top},width=800,height=760`)
   };
 
   return (

--- a/packages/opconnect/src/siwop/SIWOPContext.tsx
+++ b/packages/opconnect/src/siwop/SIWOPContext.tsx
@@ -10,10 +10,16 @@ export enum StatusState {
 }
 
 export type SIWOPSession = {
-  address: string;
-  chainId: number;
-  uid: string;
   nonce: string;
+  uid?: string;
+  address?: string;
+  avatar?: string;
+  chainId?: number;
+  avatarName?: string;
+  avatarImage?: string;
+  avatarTokenId?: string;
+  avatarContract?: string;
+  avatarChainId?: string;
 };
 
 export type SIWOPConfig = {
@@ -28,6 +34,7 @@ export type SIWOPConfig = {
     nonce: string;
     address: string;
     code_challenge: string;
+    appUrl: string;
   }) => string;
   verifyCode: (args: {
     code: string;

--- a/packages/opconnect/src/siwop/SIWOPContext.tsx
+++ b/packages/opconnect/src/siwop/SIWOPContext.tsx
@@ -37,6 +37,7 @@ export type SIWOPConfig = {
   signOut: () => Promise<boolean>;
 
   // Optional, we have default values but they can be overridden
+  appUrl?: string;
   enabled?: boolean;
   nonceRefetchInterval?: number;
   sessionRefetchInterval?: number;

--- a/packages/opconnect/src/siwop/SIWOPProvider.tsx
+++ b/packages/opconnect/src/siwop/SIWOPProvider.tsx
@@ -1,6 +1,5 @@
 import { ReactNode, useContext, useEffect, useState } from 'react';
 import { useAccount, useAccountEffect, useSignMessage } from 'wagmi';
-import { getAddress } from 'viem';
 import { useQuery } from '@tanstack/react-query';
 
 import { Context as OPConnectContext } from '../components/OPConnect';
@@ -17,8 +16,11 @@ type Props = SIWOPConfig & {
   onSignOut?: () => void;
 };
 
+const APP_URL = 'https://alpha.other.page';
+
 export const SIWOPProvider = ({
   children,
+  appUrl = APP_URL,
   enabled = true,
   nonceRefetchInterval = 1000 * 60 * 5,
   sessionRefetchInterval = 1000 * 60 * 5,
@@ -186,7 +188,7 @@ export const SIWOPProvider = ({
     // If SIWOP session no longer matches connected account, sign out
     // TODO this would have to validate against linked wallets
     // so it needs to be handled outside of the SIWOP flow for now
-    // because we can't require the wallets.read scope
+    // because we can't require the `wallets.read` scope
 
     // if (
     //   signOutOnAccountChange &&
@@ -208,6 +210,7 @@ export const SIWOPProvider = ({
   return (
     <SIWOPContext.Provider
       value={{
+        appUrl,
         enabled,
         nonceRefetchInterval,
         sessionRefetchInterval,

--- a/packages/opconnect/src/siwop/SIWOPProvider.tsx
+++ b/packages/opconnect/src/siwop/SIWOPProvider.tsx
@@ -16,11 +16,9 @@ type Props = SIWOPConfig & {
   onSignOut?: () => void;
 };
 
-const APP_URL = 'https://alpha.other.page';
-
 export const SIWOPProvider = ({
   children,
-  appUrl = APP_URL,
+  appUrl = 'https://alpha.other.page',
   enabled = true,
   nonceRefetchInterval = 1000 * 60 * 5,
   sessionRefetchInterval = 1000 * 60 * 5,
@@ -133,6 +131,7 @@ export const SIWOPProvider = ({
         nonce: nonce.data,
         address,
         code_challenge: codeChallenge, 
+        appUrl,
       });
 
       window.location.href = url;

--- a/packages/opconnect/src/siwop/useSIWOP.ts
+++ b/packages/opconnect/src/siwop/useSIWOP.ts
@@ -46,7 +46,17 @@ export const useSIWOP = ({ onSignIn, onSignOut }: UseSIWOPConfig = {}):
 
   const { clientId, session, nonce, status, signOut, signIn, resetStatus } =
     siweContextValue;
-  const { address, chainId, uid } = session.data || {};
+  const { 
+    address,
+    chainId,
+    uid,
+    avatar,
+    avatarChainId,
+    avatarContract,
+    avatarImage,
+    avatarName,
+    avatarTokenId
+  } = session.data || {};
 
   const currentStatus = address
     ? StatusState.SUCCESS
@@ -71,9 +81,15 @@ export const useSIWOP = ({ onSignIn, onSignOut }: UseSIWOPConfig = {}):
     isSignedIn,
     data: isSignedIn
       ? {
-          address: address as string,
-          chainId: chainId as number,
-          uid: uid as string,
+          address,
+          chainId,
+          uid,
+          avatar,
+          avatarName,
+          avatarImage,
+          avatarTokenId,
+          avatarContract,
+          avatarChainId,
         }
       : undefined,
     status: currentStatus,

--- a/packages/opconnect/src/siwop/useSIWOP.ts
+++ b/packages/opconnect/src/siwop/useSIWOP.ts
@@ -65,6 +65,8 @@ export const useSIWOP = ({ onSignIn, onSignOut }: UseSIWOPConfig = {}):
   const isSignedIn = !!address;
 
   return {
+    appUrl: siweContextValue.appUrl,
+    redirectUri: siweContextValue.redirectUri,
     clientId,
     isSignedIn,
     data: isSignedIn


### PR DESCRIPTION
This PR includes updates to `opconnect` and `opconnect-next-siwop`:

- [x] Improve the session/account hooks to include the logged in account and avatar
- [x] Update signed in flow to display correct user connected avatar and name